### PR TITLE
Make variable in Decoder::decode_line() immutable

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -457,10 +457,11 @@ impl Decoder {
         // 4.7.4. sample_difference
         for x in 0..width as usize {
             // 3.8. Coding of the Sample Difference
-            let mut shift = self.record.bits_per_raw_sample;
-            if self.record.colorspace_type == 1 {
-                shift = self.record.bits_per_raw_sample + 1;
-            }
+            let shift = if self.record.colorspace_type == 1 {
+                self.record.bits_per_raw_sample + 1
+            } else {
+                self.record.bits_per_raw_sample
+            };
 
             // Derive neighbours
             //


### PR DESCRIPTION
Similar to my previous PR:

https://github.com/rust-av/ffv1/pull/7

Safe guarding the variable and making the code more idiomatic.