### PR TITLE
More cleanups

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -422,38 +422,14 @@ impl Decoder {
             // See pred.go for details.
             #[allow(non_snake_case)]
             #[allow(clippy::many_single_char_names)]
-            let (T, L, t, l, tr, tl) = if record.bits_per_raw_sample == 8
-                && record.colorspace_type != 1
-            {
-                derive_borders(
-                    &buf[offset as usize..],
-                    x as isize,
-                    yy,
-                    width,
-                    height,
-                    stride,
-                )
-            } else if record.bits_per_raw_sample == 16
-                && record.colorspace_type == 1
-            {
-                derive_borders(
-                    &buf[offset as usize..],
-                    x as isize,
-                    yy,
-                    width,
-                    height,
-                    stride,
-                )
-            } else {
-                derive_borders(
-                    &buf[offset as usize..],
-                    x as isize,
-                    yy,
-                    width,
-                    height,
-                    stride,
-                )
-            };
+            let (T, L, t, l, tr, tl) = derive_borders(
+                &buf[offset as usize..],
+                x as isize,
+                yy,
+                width,
+                height,
+                stride,
+            );
 
             // See pred.go for details.
             //
@@ -504,18 +480,8 @@ impl Decoder {
 
             val &= (1 << shift) - 1;
 
-            if record.bits_per_raw_sample == 8 && record.colorspace_type != 1 {
-                buf[offset as usize + (yy as usize * stride as usize) + x] =
-                    val.as_();
-            } else if record.bits_per_raw_sample == 16
-                && record.colorspace_type == 1
-            {
-                buf[offset as usize + (yy as usize * stride as usize) + x] =
-                    val.as_();
-            } else {
-                buf[offset as usize + (yy as usize * stride as usize) + x] =
-                    val.as_();
-            }
+            buf[offset as usize + (yy as usize * stride as usize) + x] =
+                val.as_();
         }
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -490,6 +490,7 @@ impl Decoder {
     /// Planes are independent.
     ///
     /// See: 3.7.1. YCbCr
+    #[allow(clippy::needless_range_loop)]
     pub fn decode_slice_content_yuv<T>(
         current_slice: &mut Slice,
         record: &ConfigRecord,

--- a/src/golombcoder/golomb.rs
+++ b/src/golombcoder/golomb.rs
@@ -20,7 +20,7 @@ pub struct Coder<'a> {
 /// defined in 3.8.2.4.
 ///
 /// Initial Values for the VLC context state.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct State {
     drift: i32,
     error_sum: i32,
@@ -28,12 +28,8 @@ pub struct State {
     count: i32,
 }
 
-impl State {
-    /// NewState creates a Golomb-Rice state with the initial values defined in
-    /// 3.8.2.4.
-    ///
-    /// Initial Values for the VLC context state.
-    pub fn new() -> Self {
+impl Default for State {
+    fn default() -> Self {
         Self {
             drift: 0,
             error_sum: 4,

--- a/src/record.rs
+++ b/src/record.rs
@@ -25,14 +25,21 @@ pub struct ConfigRecord {
     pub initial_states: Vec<Vec<Vec<u8>>>,
     pub ec: u8,
     pub intra: u8,
+    pub width: u32,
+    pub height: u32,
 }
 
 impl ConfigRecord {
-    /// Parses the configuration record from the codec private data.
+    /// Parse the configuration record from the codec private data
+    /// and store the width and height provided by the container.
     ///
     /// See: * 4.1. Parameters
     ///      * 4.2. Configuration Record
-    pub fn parse_config_record(buf: &[u8]) -> Result<Self> {
+    pub fn parse_config_record(
+        buf: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<Self> {
         // Before we do anything, CRC check.
         //
         // See: 4.2.2. configuration_record_crc_parity
@@ -243,6 +250,8 @@ impl ConfigRecord {
             initial_states,
             ec,
             intra,
+            width,
+            height,
         };
 
         Ok(config_record)

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -10,7 +10,7 @@ pub struct InternalFrame {
     pub slices: Vec<Slice>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Copy)]
 pub struct SliceInfo {
     pub(crate) pos: isize,
     pub(crate) size: u32,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -56,11 +56,7 @@ pub fn is_keyframe(buf: &[u8]) -> bool {
 /// 9.1.1. Multi-threading Support and Independence of Slices.
 ///
 /// See: 4.8. Slice Footer
-pub fn count_slices(
-    buf: &[u8],
-    header: &mut InternalFrame,
-    ec: bool,
-) -> Result<()> {
+pub fn count_slices(buf: &[u8], ec: bool) -> Result<Vec<SliceInfo>> {
     let mut footer_size = 3;
     if ec {
         footer_size += 5;
@@ -70,7 +66,7 @@ pub fn count_slices(
     // so we can derive the slice positions within the packet, and
     // allow multithreading.
     let mut end_pos = buf.len() as isize;
-    header.slice_info = Vec::new();
+    let mut slice_info = Vec::new();
     while end_pos > 0 {
         let mut info: SliceInfo = Default::default();
 
@@ -85,7 +81,7 @@ pub fn count_slices(
 
         info.pos = end_pos - size as isize - footer_size as isize;
         let pos = info.pos;
-        header.slice_info.push(info);
+        slice_info.push(info);
         end_pos = pos;
     }
 
@@ -94,7 +90,7 @@ pub fn count_slices(
     }
 
     // Preappend here
-    header.slice_info.reverse();
+    slice_info.reverse();
 
-    Ok(())
+    Ok(slice_info)
 }


### PR DESCRIPTION
This is halfway what's needed to have slice-threading going, the next step is to store in the slice the offsets

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `builds/c-ffv1 ../data/ffv1_v3.mkv` | 1.652 ± 0.001 | 1.652 | 1.653 | 1.00 |
| `builds/go-ffv1 ../data/ffv1_v3.mkv` | 4.265 ± 0.069 | 4.216 | 4.314 | 2.58 ± 0.04 |
| `builds/rust-ffv1 ../data/ffv1_v3.mkv` | 5.576 ± 0.001 | 5.575 | 5.577 | 3.37 ± 0.00 |

