### PR TITLE
Add an accessor for ConfigRecord on Decoder

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -126,6 +126,14 @@ impl Decoder {
         Ok(decoder)
     }
 
+    /// Returns the configuration for the decoder
+    ///
+    /// The config record is parsed during decoder initialisation, and can be
+    /// accessed using this method.
+    pub fn config_record(&self) -> &ConfigRecord {
+        &self.record
+    }
+
     /// DecodeFrame takes a packet and decodes it to a ffv1.Frame.
     ///
     /// Slice threading is used by default, with one goroutine per


### PR DESCRIPTION
Users of the API will likely want to access configuration parameters
after initialising the decoder.