### PR TITLE
Updated dependencies and fixed `Context` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ thiserror = "1.0"
 members = ["ffv1-decoder", "benchmarks/rust-ffv1"]
 
 [dev-dependencies]
-av-data = "^0.3"
-av-format = "^0.3"
+av-data = "^0.4.1"
+av-format = "^0.7"
 byteorder = "1.3.4"
 matroska = { version = "0.1.0", git = "https://github.com/rust-av/matroska" }

--- a/benchmarks/rust-ffv1/Cargo.toml
+++ b/benchmarks/rust-ffv1/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 av-codec = "^0.2"
-av-data = "^0.3"
-av-format = "^0.3"
+av-data = "^0.4.1"
+av-format = "^0.7"
 ffv1 = { path = "../../" }
 matroska = { version = "0.1.0", git = "https://github.com/rust-av/matroska" }

--- a/benchmarks/rust-ffv1/src/main.rs
+++ b/benchmarks/rust-ffv1/src/main.rs
@@ -14,9 +14,8 @@ use data::params::MediaKind;
 use format::buffer::AccReader;
 use format::demuxer::{Context, Event};
 
-use matroska::demuxer::MkvDemuxer;
-
 use ffv1::decoder::Decoder;
+use matroska::demuxer::MkvDemuxer;
 
 // ffv1 decoder parameters
 #[derive(Default)]
@@ -28,7 +27,7 @@ struct DecParams {
 
 // Decodes a single ffv1 frame
 fn decode_single_frame(
-    demuxer: &mut Context,
+    demuxer: &mut Context<MkvDemuxer, AccReader<File>>,
     decoder: &mut Decoder,
 ) -> Result<(), String> {
     // The demuxer reads which event has occurred
@@ -69,7 +68,7 @@ fn main() {
     let ar = AccReader::with_capacity(4 * 1024, reader);
 
     // Set the type of demuxer, in this case, a matroska demuxer
-    let mut demuxer = Context::new(Box::new(MkvDemuxer::new()), Box::new(ar));
+    let mut demuxer = Context::new(MkvDemuxer::new(), ar);
 
     // Read matroska headers
     demuxer

--- a/ffv1-decoder/Cargo.toml
+++ b/ffv1-decoder/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/ffv1_decoder.rs"
 
 [dependencies]
 av-codec = "^0.2"
-av-data = "^0.3"
-av-format = "^0.3"
+av-data = "^0.4.1"
+av-format = "^0.7"
 byteorder = "1.3.4"
 clap = "^3"
 ffv1 = { path = "..", version = "0.0.0"}

--- a/ffv1-decoder/src/ffv1_decoder.rs
+++ b/ffv1-decoder/src/ffv1_decoder.rs
@@ -21,8 +21,8 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use data::params::MediaKind;
-use format::buffer::AccReader;
-use format::demuxer::{Context, Event};
+use format::buffer::{AccReader, Buffered};
+use format::demuxer::{Context, Event, Demuxer};
 
 use matroska::demuxer::MkvDemuxer;
 
@@ -53,7 +53,7 @@ fn write_u16_le<W: Write>(
 
 // Decodes a single ffv1 frame
 fn decode_single_frame(
-    demuxer: &mut Context,
+    demuxer: &mut Context<impl Demuxer, impl Buffered>,
     decoder: &mut Decoder,
     extradata: &[u8],
 ) -> Result<Frame, String> {
@@ -131,7 +131,7 @@ fn main() -> std::io::Result<()> {
     let ar = AccReader::with_capacity(4 * 1024, reader);
 
     // Set the type of demuxer, in this case, a matroska demuxer
-    let mut demuxer = Context::new(Box::new(MkvDemuxer::new()), Box::new(ar));
+    let mut demuxer = Context::new(MkvDemuxer::new(), ar);
 
     // Read matroska headers
     demuxer

--- a/ffv1-decoder/src/ffv1_decoder.rs
+++ b/ffv1-decoder/src/ffv1_decoder.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 
 use data::params::MediaKind;
 use format::buffer::{AccReader, Buffered};
-use format::demuxer::{Context, Event, Demuxer};
+use format::demuxer::{Context, Demuxer, Event};
 
 use matroska::demuxer::MkvDemuxer;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -464,8 +464,8 @@ impl Decoder {
         header: &SliceHeader,
         record: &ConfigRecord,
         coder: &mut Coder,
-        state: &mut Vec<Vec<Vec<u8>>>,
-        golomb_state: &mut Vec<Vec<State>>,
+        state: &mut [Vec<Vec<u8>>],
+        golomb_state: &mut [Vec<State>],
         buf: &mut [T],
         width: usize,
         height: usize,
@@ -573,7 +573,7 @@ impl Decoder {
         current_slice: &mut Slice,
         record: &ConfigRecord,
         coder: &mut Coder,
-        buf: &mut Vec<Vec<T>>,
+        buf: &mut [Vec<T>],
     ) where
         T: AsPrimitive<usize>,
         u32: AsPrimitive<T>,
@@ -616,7 +616,7 @@ impl Decoder {
         current_slice: &mut Slice,
         record: &ConfigRecord,
         coder: &mut Coder,
-        buf: &mut Vec<Vec<T>>,
+        buf: &mut [Vec<T>],
     ) where
         T: AsPrimitive<usize>,
         u32: AsPrimitive<T>,

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 
 use av_data::params::MediaKind;
 use av_format::buffer::{AccReader, Buffered};
-use av_format::demuxer::{Context, Event, Demuxer};
+use av_format::demuxer::{Context, Demuxer, Event};
 
 use matroska::demuxer::MkvDemuxer;
 


### PR DESCRIPTION
Hi guys, I made another attempt at fixing a bug. 🤪
Upon cloning/trying the code I found out that it crashed with the example provided in `README.md` 
This PR should fix that.

I also made an attempt at fixing Issue #34 ...
Unless I completely misinterpreted the stack trace: it seems the issue should be reported on [matroska](https://github.com/rust-av/matroska) codec, am I wrong?